### PR TITLE
Adicionado registro de usuario

### DIFF
--- a/graphql/resolvers.js
+++ b/graphql/resolvers.js
@@ -120,9 +120,8 @@ const resolvers = {
     addUser: async (_, args) => {
       try {
         let response = await Schemas.User.create({
-          userName: args.userName,
-          userPassword: args.userPassword,
-          userEmail: args.userEmail,
+          username: args.username,
+          nickname: args.nickname,
           userExp: 0,
           userLevel: 0,
           userPermission: args.userPermission,
@@ -140,9 +139,8 @@ const resolvers = {
       try {
         let userToUpdate = await Schemas.User.findById(
           args._id,
-          `userName
-          userPassword
-          userEmail
+          `username
+          nickname
           userExp
           userLevel
           userPermission
@@ -158,9 +156,8 @@ const resolvers = {
         let response = await Schemas.User.findOneAndUpdate({ _id: args._id },
           {
             $set: {
-              userName: args.userName == null ? userToUpdate.userName : args.userName,
-              userPassword: args.userPassword == null ? userToUpdate.userPassword : args.userPassword,
-              userEmail: args.userEmail == null ? userToUpdate.userEmail : args.userEmail,
+              username: args.username == null ? userToUpdate.username : args.username,
+              nickname: args.nickname == null ? userToUpdate.nickname : args.nickname,
               userExp: args.userExp == null ? userToUpdate.userExp : args.userExp,
               userLevel: args.userLevel == null ? userToUpdate.userLevel : args.userLevel,
               userPermission: args.userPermission == null ? userToUpdate.userPermission : args.userPermission,

--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -28,9 +28,8 @@ const typeDefs = gql`
 
   type User {
     id: String
-    userName: String
-    userPassword: String
-    userEmail: String
+    username: String
+    nickname: String
     userExp: Int
     userLevel: Int
     userPermission: PermissionLevels
@@ -134,9 +133,8 @@ const typeDefs = gql`
 
     # ############### USER ###############
     addUser(
-      userName: String
-      userPassword: String
-      userEmail: String
+      username: String
+      nickname: String
       userExp: Int
       userLevel: Int
       userPermission: PermissionLevels
@@ -150,9 +148,8 @@ const typeDefs = gql`
     deleteUser(_id: String): User,
     updateUser(
       _id: String
-      userName: String
-      userPassword: String
-      userEmail: String
+      username: String
+      nickname: String
       userExp: Int
       userLevel: Int
       userPermission: PermissionLevels

--- a/index.js
+++ b/index.js
@@ -9,10 +9,11 @@ const bodyParser = require('body-parser');
 const expressSession = require('express-session')({
 	secret: 'secret',
 	resave: true,
-  rolling: true,
+	rolling: true,
 	saveUninitialized: false,
 	cookie: { maxAge: 720000 }
 })
+const Schemas = require('./models/Schemas')
 
 const startServer = async () => {
 	const app = express()
@@ -40,12 +41,11 @@ const startServer = async () => {
 	});
 	const passportLocalMongoose = require('passport-local-mongoose');
 
-	const Schema = mongoose.Schema;
-	const UserDetail = new Schema({
-		username: String,
-		password: String
-	});
-
+	
+	
+	
+	
+	
 	const uri = process.env.URI;
 
 	await mongoose.connect(uri, { useNewUrlParser: true, useCreateIndex: true, useUnifiedTopology: true, useFindAndModify: false })
@@ -53,9 +53,8 @@ const startServer = async () => {
 	if (mongoose.connection.readyState) {
 		console.log("MongoDB database connection established successfully")
 	}
-
-	UserDetail.plugin(passportLocalMongoose);
-	const UserDetails = mongoose.model('userInfo', UserDetail, 'userInfo');
+	
+	const UserDetails = Schemas.User;
 
 	passport.use(UserDetails.createStrategy());
 
@@ -136,6 +135,18 @@ const startServer = async () => {
 	app.listen({ port: process.env.PORT || 4000 }, () =>
 		console.log(`Server ready at http://localhost:${process.env.PORT || 4000}`)
 	)
+
+	app.post('/register', (req, res) => {
+		UserDetails.register({
+			username: req.body.username,
+			userExp: 0,
+			userLevel: 0,
+			userPermission: 'STANDARD',
+			userRanking: 'beginner',
+			nickname: req.body.nickname,
+			active: false
+		}, req.body.password).then(response => res.send(response)).catch(e => res.send(e));
+	})
 
 	// UserDetails.register({ username: 'bruno', active: false }, '44444444');
 	// Teste PR

--- a/models/Schemas.js
+++ b/models/Schemas.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
+const passportLocalMongoose = require('passport-local-mongoose');
 
 const postSchema = new Schema({
     postTags: {
@@ -93,6 +94,14 @@ const postSchema = new Schema({
 });
 
 const userSchema = new Schema({
+    username: {
+        type: String,
+        required: true,
+    },
+    nickname: {
+        type: String,
+        required: true,
+    },
     userReports: {
         type: [String],
         required: false,
@@ -131,24 +140,6 @@ const userSchema = new Schema({
     },
     userExp: {
         type: Number,
-        required: true,
-        unique: false,
-        trim: true
-    },
-    userEmail: {
-        type: String,
-        required: true,
-        unique: true,
-        trim: true
-    },
-    userName: {
-        type: String,
-        required: true,
-        unique: true,
-        trim: true
-    },
-    userPassword: {
-        type: String,
         required: true,
         unique: false,
         trim: true
@@ -260,8 +251,10 @@ const categorySchema = new Schema({
     collection: "categories"
 });
 
+userSchema.plugin(passportLocalMongoose);
+
 let Post = mongoose.models.Post || mongoose.model('Post', postSchema);
-let User = mongoose.models.User || mongoose.model('User', userSchema);
+let User = mongoose.models.User || mongoose.model('User', userSchema, 'User');
 let Report = mongoose.models.Report || mongoose.model('Report', reportSchema);
 let Comment = mongoose.models.Comment || mongoose.model('Comment', commentSchema);
 let Category = mongoose.models.Category || mongoose.model('Category', categorySchema);


### PR DESCRIPTION
### Resumo:
Adicionei uma rota para registro de usuários. Fiz algumas alterações no Schema de usuários. As mudanças envolvem a remoção de alguns campos e adição de outros.

### IMPORTANTE!
Uma das mudanças mais importantes desta atualização envolve a alteração de um dos campos do Schema de usuários. **Antes**, o Schema de usuários possuía um campo chamado `userName`, o qual era usado para armazenar o login do usuário. Além deste, existia um outro campo chamado `userEmail`, que seria usado para armazenar o email do usuário. Com esta atualização, **os campo `userName` e `userEmail` não existem mais** e foram substituídos por um campo chamado `username`, o qual **será usado para armazenar o email do usuário, e será o campo usado para logar na plataforma**.

### Rota para registro de usuários:
A rota `POST /register` pode ser usada para registro de novos usuários. Apenas **3 campos** devem ser passados **no corpo da chamada**. Os campos que devem ser passados são:
- `username` **_STRING_** (Email do usuário)
- `nickname` **_STRING_** (Apelido do usuário)
- `password` **_STRING_** (Senha do usuário)

**Exemplo**:

`POST http://localhost:4000/register`

_Body_:
```
{
    "username": "bruno@mail.com",
    "nickname": "Bruninn",
    "password": "12344321"
}
```

### ADIÇÕES (_Schema_)
**User**
- `username` **_STRING_**
Email do usuário, usado para logar na plataforma. Substitui os antigos campos `userName` e `userEmail`, os quais foram removidos. O novo campo faz as funções dos antigos `userName` e `userEmail` usando um único campo.

- `nickname` **_STRING_**
Apelido do usuário. **É o que será mostrado no frontend** uma vez que o usuário esteja logado.

### REMOÇÕES (_Schema_)
**User**
- `userName`
Era usado para armazenar o login do usuário. Este campo era usado para logar na plataforma quando usado em conjunto com a senha.

- `userPassword`
Este campo nunca foi usado. A ideia era usa-lo para armazenar a senha do usuário, porém o método de registro de usuários que acabou por ser implementado não fará uso deste campo, tornando-o inutilizável.

- `userEmail`
Era usado para armazenar o email do usuário. Foi removido uma vez que o novo campo `username` fará a função dos campos `userName` e `userEmail`.