### PR TITLE
Reset de senha

### DIFF
--- a/graphql/typeDefs.js
+++ b/graphql/typeDefs.js
@@ -28,6 +28,7 @@ const typeDefs = gql`
 
   type User {
     id: String
+    resetToken: String
     username: String
     nickname: String
     userExp: Int

--- a/models/Schemas.js
+++ b/models/Schemas.js
@@ -94,6 +94,10 @@ const postSchema = new Schema({
 });
 
 const userSchema = new Schema({
+    resetToken: {
+        type: String,
+        required: true,
+    },
     username: {
         type: String,
         required: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,6 +1790,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
     "binary-extensions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "apollo-server-express": "^2.14.2",
     "audit": "0.0.6",
     "axios": "^0.19.2",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.19.0",
     "connect-ensure-login": "^0.1.1",
     "cors": "^2.8.5",


### PR DESCRIPTION
# Resumo
Adicionei um endpoint pra função de reset de senha, e adicionei um novo campo no Schema de usuário que será usado pra recuperação de senha.

### Mudanças no Schema _"User"_
#### Adições
- `resetToken`: **_String_**
Esse novo campo vai ser usado pra recuperação de senha. Uma vez que o reset de senha requer a senha atual pra gerar uma nova, é necessário ter uma alternativa caso o usuário perca a senha atual. Se isso acontecer, o usuário poderá usar seu _resetToken_ para recuperar a senha. O _resetToken_ *será enviado por email caso o usuário esqueça ou perca sua senha atual.

*Apesar de o campo já ter sido adicionado, a função de enviar o _resetToken_ por email **ainda não foi**.

### Endpoint pra reset de senha
O novo endpoint `POST /reset` pode ser usado para cadastrar uma senha nova. É necessário passar a senha atual na chamada.

**Exemplo**:
`POST http://localhost:4000/reset`

_Body_:
```
{
    "username": "bruno@mail.com",
    "password": "44444444",
    "newPassword": "12344321"
}
```