### PR TITLE
commentReplis has been changed to not unique

### DIFF
--- a/models/Schemas.js
+++ b/models/Schemas.js
@@ -208,7 +208,7 @@ const commentSchema = new Schema({
     commentReplies: {
         type: [String],
         required: false,
-        unique: true,
+        unique: false,
         trim: true
     },
     commentLikes: {


### PR DESCRIPTION
## Mudanças

### commentSchema
O campo `commentReplies` não é mais _unique_, pois essa configuração estava causando alguns bugs.